### PR TITLE
Fix ErrorException error on section' XML

### DIFF
--- a/src/services/SitemapService.php
+++ b/src/services/SitemapService.php
@@ -304,7 +304,7 @@ class SitemapService extends Component
 			if ($seoFieldHandle !== null) {
 				/** @var SeoData $seoField */
 				$seoField = $item->$seoFieldHandle;
-				if (property_exists($seoField, 'advanced') && $robots = $seoField->advanced['robots'])
+				if (is_object($seoField) && property_exists($seoField, 'advanced') && $robots = $seoField->advanced['robots'])
 					if (in_array('noindex', $robots))
 						continue;
 			}


### PR DESCRIPTION
Check if `$seoField` is an object before looking for the `advanced` pro to avoid this error on by-section sitemap:
Trying to get property 'advanced' of non-object

Fixes # .

Changes proposed in this pull request:

- 
- 
- 